### PR TITLE
Removed unnecessary whitespaces in week 3 exercise 5 reference output

### DIFF
--- a/Uebungen/Woche_3.md
+++ b/Uebungen/Woche_3.md
@@ -68,13 +68,13 @@ Schreiben Sie in Java ein Programm, das auf der Kommandozeile exakt die folgende
 
 ```text
 *.*.*.*.*
-.*.*.*.*.      
+.*.*.*.*.
 *.*.*.*.*
-.*.*.*.*.      
+.*.*.*.*.
 *.*.*.*.*
-.*.*.*.*.      
+.*.*.*.*.
 *.*.*.*.*
-.*.*.*.*.      
+.*.*.*.*.
 *.*.*.*.*
 
 ```


### PR DESCRIPTION
Ein Student hat in seiner Abgabe darauf hingewiesen, dass die Referenzausgabe extra Leerzeichen enthielt, die bei VPL nicht gewünscht sind.